### PR TITLE
Import six directly instead of via sklearn

### DIFF
--- a/AUTHORS.txt
+++ b/AUTHORS.txt
@@ -6,3 +6,4 @@ Luca Soldaini
 Simon Stiebellehner
 Songwei Ge
 Cheng Rui
+Thien Bui

--- a/pyltr/data/letor.py
+++ b/pyltr/data/letor.py
@@ -5,8 +5,8 @@ Various utilities for converting data from/to Microsoft's LETOR format.
 """
 
 import numpy as np
-import sklearn.externals.six
-from sklearn.externals.six.moves import range
+import six
+from six.moves import range
 
 
 def iter_lines(lines, has_targets=True, one_indexed=True, missing=0.0):
@@ -100,7 +100,7 @@ def read_dataset(source, has_targets=True, one_indexed=True, missing=0.0):
         Comment vector (see `iter_lines`).
 
     """
-    if isinstance(source, sklearn.externals.six.string_types):
+    if isinstance(source, six.string_types):
         source = source.splitlines()
 
     max_width = 0

--- a/pyltr/metrics/_metrics.py
+++ b/pyltr/metrics/_metrics.py
@@ -1,5 +1,5 @@
 import numpy as np
-from sklearn.externals.six.moves import range
+from six.moves import range
 from ..util.group import check_qids, get_groups
 from ..util.sort import get_sorted_y
 

--- a/pyltr/metrics/ap.py
+++ b/pyltr/metrics/ap.py
@@ -8,7 +8,7 @@ TODO: better docs
 
 import numpy as np
 from . import Metric
-from sklearn.externals.six.moves import range
+from six.moves import range
 
 
 class AP(Metric):

--- a/pyltr/metrics/dcg.py
+++ b/pyltr/metrics/dcg.py
@@ -8,7 +8,7 @@ TODO: better docs
 
 import numpy as np
 from . import gains, Metric
-from sklearn.externals.six import moves
+from six import moves
 
 _EPS = np.finfo(np.float64).eps
 range = moves.range

--- a/pyltr/metrics/err.py
+++ b/pyltr/metrics/err.py
@@ -8,7 +8,7 @@ TODO: better docs
 
 import numpy as np
 from . import gains, Metric
-from sklearn.externals.six import moves
+from six import moves
 
 range = moves.range
 _EPS = np.finfo(np.float64).eps

--- a/pyltr/metrics/kendall.py
+++ b/pyltr/metrics/kendall.py
@@ -8,7 +8,7 @@ TODO: better docs
 
 import numpy as np
 from . import Metric
-from sklearn.externals.six.moves import range
+from six.moves import range
 
 
 _EPS = np.finfo(np.float64).eps

--- a/pyltr/metrics/roc.py
+++ b/pyltr/metrics/roc.py
@@ -8,7 +8,7 @@ TODO: better docs
 
 import numpy as np
 from . import Metric
-from sklearn.externals.six.moves import range
+from six.moves import range
 
 
 class AUCROC(Metric):

--- a/pyltr/models/lambdamart.py
+++ b/pyltr/models/lambdamart.py
@@ -26,7 +26,7 @@ from . import AdditiveModel
 from .. import metrics
 from ..util.group import check_qids, get_groups
 from ..util.sort import get_sorted_y_positions
-from sklearn.externals.six.moves import range
+from six.moves import range
 
 
 class LambdaMART(AdditiveModel):
@@ -475,7 +475,7 @@ class LambdaMART(AdditiveModel):
             raise ValueError("query_subsample must be in (0,1] but "
                              "was %r" % self.query_subsample)
 
-        if isinstance(self.max_features, sklearn.externals.six.string_types):
+        if isinstance(self.max_features, six.string_types):
             if self.max_features == "auto":
                 max_features = self.n_features
             elif self.max_features == "sqrt":

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup, find_packages
 
 setup(
     name='pyltr',
-    version='0.2.4',
+    version='0.2.5',
     description='Python learning to rank (LTR) toolkit.',
     author='Jerry Ma',
     author_email='jmnospam@mail.com',

--- a/setup.py
+++ b/setup.py
@@ -22,6 +22,7 @@ setup(
         'pandas',
         'scipy',
         'scikit-learn',
+        'six',
     ],
 
     zip_safe=True,


### PR DESCRIPTION
Sklearn have removed `externals.six` in version 0.23
This library should be updated to import six directly intead