### PR TITLE
Remove a deprecated parameter

### DIFF
--- a/pyltr/models/lambdamart.py
+++ b/pyltr/models/lambdamart.py
@@ -338,7 +338,6 @@ class LambdaMART(AdditiveModel):
         tree = sklearn.tree.DecisionTreeRegressor(
             criterion='friedman_mse',
             splitter='best',
-            presort=True,
             max_depth=self.max_depth,
             min_samples_split=self.min_samples_split,
             min_samples_leaf=self.min_samples_leaf,


### PR DESCRIPTION
This pull request is to remove the deprecated parameter.

presort was deprecated in v0.24.
https://scikit-learn.org/0.23/modules/generated/sklearn.tree.DecisionTreeRegressor.html#sklearn.tree.DecisionTreeRegressor

So, if we use the latest scikit-learn, this library is not running.

```shell
Traceback (most recent call last):
  File "sample_pyltr/main.py", line 52, in <module>
    main()
  File "sample_pyltr/main.py", line 39, in main
    model.fit(X_train, y_train, qid_train, monitor=monitor)
  File "/home/wararaki/.cache/pypoetry/virtualenvs/sample-pyltr-KjsgfJ4m-py3.8/lib/python3.8/site-packages/pyltr/models/lambdamart.py", line 200, in fit
    n_stages = self._fit_stages(X, y, qids, y_pred,
  File "/home/wararaki/.cache/pypoetry/virtualenvs/sample-pyltr-KjsgfJ4m-py3.8/lib/python3.8/site-packages/pyltr/models/lambdamart.py", line 406, in _fit_stages
    y_pred = self._fit_stage(i, X, y, qids, y_pred, sample_weight,
  File "/home/wararaki/.cache/pypoetry/virtualenvs/sample-pyltr-KjsgfJ4m-py3.8/lib/python3.8/site-packages/pyltr/models/lambdamart.py", line 338, in _fit_stage
    tree = sklearn.tree.DecisionTreeRegressor(
TypeError: __init__() got an unexpected keyword argument 'presort'
```

The parameter is not exist in the current stable version.
https://scikit-learn.org/stable/modules/generated/sklearn.tree.DecisionTreeRegressor.html
